### PR TITLE
Removed mandatory dependencies on play-json for issue #3

### DIFF
--- a/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
+++ b/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
@@ -18,21 +18,19 @@ object EmailAddress {
   }
 
   implicit def emailToString(e: EmailAddress): String = e.value
-
-  lazy implicit val emailAddressFormat = PlayJsonFormats.emailAddressFormat
-
 }
+
 object PlayJsonFormats {
   import play.api.libs.json._
 
-  implicit val emailAddressReads = new Reads[EmailAddress] {
+  val emailAddressReads = new Reads[EmailAddress] {
     def reads(js: JsValue): JsResult[EmailAddress] = js.validate[String].flatMap {
       case s if EmailAddress.isValid(s) => JsSuccess(EmailAddress(s))
       case s => JsError("not a valid email address")
     }
   }
-  implicit val emailAddressWrites = new Writes[EmailAddress] {
+  val emailAddressWrites = new Writes[EmailAddress] {
     def writes(e: EmailAddress): JsValue = JsString(e.value)
   }
-  implicit val emailAddressFormat = Format(emailAddressReads, emailAddressWrites)
+  val emailAddressFormat = Format(emailAddressReads, emailAddressWrites)
 }

--- a/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
+++ b/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
@@ -23,14 +23,13 @@ object EmailAddress {
 object PlayJsonFormats {
   import play.api.libs.json._
 
-  val emailAddressReads = new Reads[EmailAddress] {
+  implicit val emailAddressReads = new Reads[EmailAddress] {
     def reads(js: JsValue): JsResult[EmailAddress] = js.validate[String].flatMap {
       case s if EmailAddress.isValid(s) => JsSuccess(EmailAddress(s))
       case s => JsError("not a valid email address")
     }
   }
-  val emailAddressWrites = new Writes[EmailAddress] {
+  implicit val emailAddressWrites = new Writes[EmailAddress] {
     def writes(e: EmailAddress): JsValue = JsString(e.value)
   }
-  val emailAddressFormat = Format(emailAddressReads, emailAddressWrites)
 }

--- a/src/test/scala/uk/gov/hmrc/emailaddress/PlayJsonFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/PlayJsonFormatsSpec.scala
@@ -4,6 +4,9 @@ import org.scalatest.{WordSpec, Matchers}
 import play.api.libs.json.{Json, JsError, JsSuccess, JsString}
 
 class PlayJsonFormatsSpec extends WordSpec with Matchers {
+
+  implicit val format = PlayJsonFormats.emailAddressFormat
+
   "Reading an EmailAddress from JSON" should {
 
     "work for a valid email address" in {

--- a/src/test/scala/uk/gov/hmrc/emailaddress/PlayJsonFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/PlayJsonFormatsSpec.scala
@@ -5,7 +5,7 @@ import play.api.libs.json.{Json, JsError, JsSuccess, JsString}
 
 class PlayJsonFormatsSpec extends WordSpec with Matchers {
 
-  implicit val format = PlayJsonFormats.emailAddressFormat
+  import PlayJsonFormats._
 
   "Reading an EmailAddress from JSON" should {
 


### PR DESCRIPTION
OK then, how about this approach?

The json format is still available if you want it (i.e. reference from PlayJsonFormats), but it's not forced into EmailAddress regardless of whether you want one or not.

(Also the `implicit` on PlayJsonFormat's members don't seem to be doing anything for us)
