### PR TITLE
Check for non alpha-numerics in mailbox

### DIFF
--- a/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
+++ b/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala
@@ -27,8 +27,8 @@ case class EmailAddress(value: String) extends StringValue {
 }
 
 object EmailAddress {
-  final private[emailaddress] val validDomain = """\b([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)\b""".r
-  final private[emailaddress] val validEmail = """\b([a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)\b""".r
+  final private[emailaddress] val validDomain = """^([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$""".r
+  final private[emailaddress] val validEmail = """^([a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$""".r
 
   def isValid(email: String) = email match {
     case validEmail(_,_) => true

--- a/src/main/scala/uk/gov/hmrc/emailaddress/StringValue.scala
+++ b/src/main/scala/uk/gov/hmrc/emailaddress/StringValue.scala
@@ -22,6 +22,6 @@ object StringValue {
 }
 
 trait StringValue {
-  val value: String
+  def value: String
   override def toString: String = value
 }

--- a/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressGenerators.scala
@@ -30,15 +30,16 @@ trait EmailAddressGenerators {
 
   def chars(chars: String) = Gen.choose(0, chars.length - 1).map(chars.charAt)
 
-  val validMailbox = nonEmptyString(oneOf(alphaChar, chars(".!#$%&’*+/=?^_`{|}~-")))
+  val validMailbox = nonEmptyString(oneOf(alphaChar, chars(".!#$%&’*+/=?^_`{|}~-"))).label("mailbox")
 
-  val validDomain = for {
+  val validDomain = (for {
     topLevelDomain <- nonEmptyString(alphaChar)
     otherParts <- listOf(nonEmptyString(alphaChar))
-  } yield (otherParts :+ topLevelDomain).mkString(".")
+  } yield (otherParts :+ topLevelDomain).mkString(".")).label("domain")
 
-  val validEmailAddresses = for {
-    mailbox <- validMailbox
-    domain <- validDomain
-  } yield s"$mailbox@$domain"
+  def validEmailAddresses(mailbox: Gen[String] = validMailbox, domain: Gen[String] = validDomain) =
+    for {
+      mailbox <- mailbox
+      domain <- domain
+    } yield s"$mailbox@$domain"
 }

--- a/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressSpec.scala
@@ -24,13 +24,25 @@ class EmailAddressSpec extends WordSpec with Matchers with PropertyChecks with E
 
   "Creating an EmailAddress class" should {
     "work for a valid email" in {
-      forAll (validEmailAddresses) { address =>
+      forAll(validEmailAddresses) { address =>
         EmailAddress(address).value should be(address)
       }
     }
 
     "throw an exception for an invalid email" in {
       an [IllegalArgumentException] should be thrownBy { EmailAddress("sausages") }
+    }
+
+    "throw an exception for an valid email starting with invalid characters" in {
+      forAll(validEmailAddresses) { address =>
+        an [IllegalArgumentException] should be thrownBy { EmailAddress("§"+ address) }
+      }
+    }
+
+    "throw an exception for an valid email ending with invalid characters" in {
+      forAll(validEmailAddresses) { address =>
+        an [IllegalArgumentException] should be thrownBy { EmailAddress(address + "§") }
+      }
     }
 
     "throw an exception for an empty email" in {
@@ -101,6 +113,7 @@ class EmailAddressSpec extends WordSpec with Matchers with PropertyChecks with E
   }
 
   "A email address mailbox" should {
+
     "be extractable from an address" in forAll (validMailbox, validDomain) { (mailbox, domain) =>
       EmailAddress(s"$mailbox@$domain").mailbox should (be (a[Mailbox]) and have ('value (mailbox)))
     }

--- a/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/EmailAddressSpec.scala
@@ -24,7 +24,7 @@ class EmailAddressSpec extends WordSpec with Matchers with PropertyChecks with E
 
   "Creating an EmailAddress class" should {
     "work for a valid email" in {
-      forAll(validEmailAddresses) { address =>
+      forAll(validEmailAddresses()) { address =>
         EmailAddress(address).value should be(address)
       }
     }
@@ -34,13 +34,13 @@ class EmailAddressSpec extends WordSpec with Matchers with PropertyChecks with E
     }
 
     "throw an exception for an valid email starting with invalid characters" in {
-      forAll(validEmailAddresses) { address =>
+      forAll(validEmailAddresses()) { address =>
         an [IllegalArgumentException] should be thrownBy { EmailAddress("§"+ address) }
       }
     }
 
     "throw an exception for an valid email ending with invalid characters" in {
-      forAll(validEmailAddresses) { address =>
+      forAll(validEmailAddresses()) { address =>
         an [IllegalArgumentException] should be thrownBy { EmailAddress(address + "§") }
       }
     }

--- a/src/test/scala/uk/gov/hmrc/emailaddress/ObfuscateedEmailAddressSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/emailaddress/ObfuscateedEmailAddressSpec.scala
@@ -26,21 +26,25 @@ class ObfuscateedEmailAddressSpec extends WordSpec with Matchers with PropertyCh
       ObfuscatedEmailAddress("abcdef@example.com").value should be("a****f@example.com")
     }
 
-    "work for a valid email address with a three letter mailbox" in {
-      ObfuscatedEmailAddress("abc@example.com").value should be("a*c@example.com")
+    "work for a valid email address with a single letter mailbox" in {
+      ObfuscatedEmailAddress("a@example.com").value should be("*@example.com")
     }
 
     "work for a valid email address with a two letter mailbox" in {
       ObfuscatedEmailAddress("ab@example.com").value should be("**@example.com")
     }
 
-    "work for a valid email address with a single letter mailbox" in {
-      ObfuscatedEmailAddress("a@example.com").value should be("*@example.com")
+    "work for a valid email address with a three letter mailbox" in {
+      ObfuscatedEmailAddress("abc@example.com").value should be("a*c@example.com")
     }
 
-    "work for valid email addresses" in {
-      forAll (validEmailAddresses) { address =>
-        ObfuscatedEmailAddress(address).value should ((not be address) and include("*"))
+    "do nothing for a valid email address with a three letter mailbox with * in the middle" in {
+      ObfuscatedEmailAddress("a*c@example.com").value should be("a*c@example.com")
+    }
+
+    "work for valid email addresses with a mailbox longer than three chars" in {
+      forAll (validEmailAddresses(mailbox = validMailbox.suchThat(_.length > 3))) { address =>
+        EmailAddress(address).obfuscated.value should ((not be address) and include("*"))
       }
     }
 


### PR DESCRIPTION
This improves the property tests (which only tested alpha-numeric chars). It also
fixes a bug where non alpha-numerics at the begining/end of email addresses.
