### PR TITLE
[DC 7881] - Upgrade Play, Scala and Scoverage version to address Bobby rules' violations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import LibDependencies.PlayVersion
-import sbt.Def
 
 val appName = "emailaddress"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,10 @@
 import LibDependencies.PlayVersion
+import sbt.Def
 
 val appName = "emailaddress"
 
 lazy val scala2_12 = "2.12.16"
-lazy val scala2_13 = "2.13.12"
+lazy val scala2_13 = "2.13.16"
 
 ThisBuild / scalaVersion       := scala2_13
 ThisBuild / majorVersion       := 4
@@ -41,7 +42,7 @@ lazy val play30 = Project(s"$appName-play-30", file("play-30"))
   )
   .settings(commonSettings)
 
-def sharedSources = Seq(
+def sharedSources: Seq[Def.Setting[Seq[File]]] = Seq(
   Compile / unmanagedSourceDirectories   += baseDirectory.value / "../shared/src/main/scala",
   Compile / unmanagedResourceDirectories += baseDirectory.value / "../shared/src/main/resources",
   Test    / unmanagedSourceDirectories   += baseDirectory.value / "../shared/src/test/scala",

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -11,15 +11,14 @@ object LibDependencies {
     case object Play29 extends PlayVersion
 
     case object Play30 extends PlayVersion
-
   }
 
-  def compileDependencies(playVersion: PlayVersion) = playVersion match {
-    case PlayVersion.Play29 => "com.typesafe.play" %% "play" % "2.9.0"
-    case PlayVersion.Play30 => "org.playframework" %% "play" % "3.0.0"
+  def compileDependencies(playVersion: PlayVersion): ModuleID = playVersion match {
+    case PlayVersion.Play29 => "com.typesafe.play" %% "play" % "2.9.9"
+    case PlayVersion.Play30 => "org.playframework" %% "play" % "3.0.9"
   }
 
-  val testDependencies = Seq(
+  val testDependencies: Seq[ModuleID] = Seq(
     "org.scalatest"       %% "scalatest"       % "3.2.17",
     "org.scalatestplus"   %% "scalacheck-1-17" % "3.2.14.0",
     "org.pegdown"          % "pegdown"         % "1.6.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
 addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.15.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.15.0")
+addSbtPlugin("uk.gov.hmrc"   % "sbt-auto-build" % "3.24.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")


### PR DESCRIPTION
Description - Though this library is deprecated but it is still being used by other services and that is causing the Bobby rules' violations for those services hence fail their deployment in the respective environments. 

Below have been done as part of this PR

- Upgrade Scala, Play, Scoverage, sbt and sbt auto buuild version
- Minor refactoring (added the return type)